### PR TITLE
bugfix:compile error in mingw32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ clean:
 mingw: lsocket.dll
 
 lsocket.dll : lsocket.c win_compat.c
-	$(CC) -o $@ -Wall $(OPT) $(DBG) $(INCDIRS) $^ $(LDFLAGS) -lws2_32 -L/usr/local/bin -llua53
+	$(CC) -std=c99 -o $@ -Wall $(OPT) $(DBG) $(INCDIRS) $^ $(LDFLAGS) -lws2_32 -L/usr/local/bin -llua53

--- a/lsocket.c
+++ b/lsocket.c
@@ -5,6 +5,9 @@
  * Gunnar Zötl <gz@tset.de>, 2013
  * Released under MIT/X11 license. See file LICENSE for details.
  */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0502
+#endif
 
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
1.confliciting types for 'nanosleep'(unistd.h)
2.undefine 'getaddrinfo'
