### PR TITLE
iphlpapi.h 使用小写允许 Linux 交叉编译

### DIFF
--- a/win_compat.c
+++ b/win_compat.c
@@ -1,6 +1,6 @@
 #define WIN_COMPAT_IMPL
 #include "win_compat.h"
-#include "Iphlpapi.h"
+#include "iphlpapi.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
在 Linux 用 mingw-x64 交叉编译，因为文件系统区分了大小写找不到文件，改成小写就行了。